### PR TITLE
Add disabled version of Open

### DIFF
--- a/usb_disabled.go
+++ b/usb_disabled.go
@@ -44,3 +44,8 @@ func EnumerateRaw(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
 func EnumerateHid(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
 	return nil, nil
 }
+
+// Open connects to a previsouly discovered USB device.
+func (info DeviceInfo) Open() (Device, error) {
+	return nil, ErrUnsupportedPlatform
+}


### PR DESCRIPTION
Geth doesn't compile on OpenBSD and, presumably, other platforms that have libusb available in their install but are not supported by this library. This is because `usb_disabled.go` doesn't implement `DeviceInfo.Open`. This PR adds a dummy function to make sure that geth builds.