### PR TITLE
appveyor: bump to Go 1.12.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 install:
   - rmdir C:\go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go1.12.6.windows-%GOARCH%.zip
-  - 7z x go1.12.6.windows-%GOARCH%.zip -y -oC:\ > NUL
+  - 7z x go1.12.8.windows-%GOARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ environment:
 
 install:
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.12.6.windows-%GOARCH%.zip
-  - 7z x go1.12.8.windows-%GOARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.12.9.windows-%GOARCH%.zip
+  - 7z x go1.12.9.windows-%GOARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release.html#go1.12.minor