### PR TITLE
revert back to previous behaviour, fixes #7

### DIFF
--- a/hidapi/windows/hid.c
+++ b/hidapi/windows/hid.c
@@ -428,7 +428,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			if (str) {
 				len = strlen(str);
 				cur_dev->path = (char*) calloc(len+1, sizeof(char));
-				strncpy(cur_dev->path, str, sizeof(cur_dev->path));
+				strncpy(cur_dev->path, str, len+1);
 				cur_dev->path[len] = '\0';
 			}
 			else

--- a/hidapi/windows/hid.c
+++ b/hidapi/windows/hid.c
@@ -74,6 +74,8 @@ extern "C" {
 	#pragma warning(disable:4996)
 #endif
 
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Reverts that windows-fix which caused the path to be cropped. I haven't tested this on windows, and I'm not sure how to find out what pragma directives to use to get rid of any warnings. 