### PR TITLE
Add dummy Go packages for vendoring of C files

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,18 @@
+// +build dummy
+
+// This file is part of a workaround for `go mod vendor` which won't vendor
+// C files if there's no Go file in the same directory.
+// This would prevent the c/sqlite3.c file to be vendored.
+//
+// This Go file imports the c directory where there is another dummy.go file which
+// is the second part of this workaround.
+//
+// These two files combined make it so `go mod vendor` behaves correctly.
+//
+// See this issue for reference: https://github.com/golang/go/issues/26366
+
+package sqlite
+
+import (
+	_ "github.com/karalabe/usb/hidapi/c"
+)

--- a/dummy.go
+++ b/dummy.go
@@ -2,7 +2,7 @@
 
 // This file is part of a workaround for `go mod vendor` which won't vendor
 // C files if there's no Go file in the same directory.
-// This would prevent the c/sqlite3.c file to be vendored.
+// This would prevent the hidapi/hidapi/hidapi.h file to be vendored.
 //
 // This Go file imports the c directory where there is another dummy.go file which
 // is the second part of this workaround.
@@ -11,8 +11,15 @@
 //
 // See this issue for reference: https://github.com/golang/go/issues/26366
 
-package sqlite
+package main
 
 import (
-	_ "github.com/karalabe/usb/hidapi/c"
+	_ "github.com/karalabe/usb/hidapi"
+	_ "github.com/karalabe/usb/hidapi/hidapi"
+	_ "github.com/karalabe/usb/hidapi/libusb"
+	_ "github.com/karalabe/usb/hidapi/mac"
+	_ "github.com/karalabe/usb/hidapi/windows"
+	_ "github.com/karalabe/usb/libusb"
+	_ "github.com/karalabe/usb/libusb/libusb"
+	_ "github.com/karalabe/usb/libusb/libusb/os"
 )

--- a/hidapi/dummy.go
+++ b/hidapi/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package hidapi

--- a/hidapi/hidapi/dummy.go
+++ b/hidapi/hidapi/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package c

--- a/hidapi/libusb/dummy.go
+++ b/hidapi/libusb/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package libusb

--- a/hidapi/mac/dummy.go
+++ b/hidapi/mac/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package mac

--- a/hidapi/windows/dummy.go
+++ b/hidapi/windows/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package windows

--- a/libusb/dummy.go
+++ b/libusb/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package libusb

--- a/libusb/libusb/dummy.go
+++ b/libusb/libusb/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package libusb

--- a/libusb/libusb/os/dummy.go
+++ b/libusb/libusb/os/dummy.go
@@ -4,4 +4,4 @@
 //
 // This Go file is part of a workaround for `go mod vendor`.
 // Please see the file dummy.go at the root of the module for more information.
-package hidapi
+package os


### PR DESCRIPTION
Go won't vendor C files if there are no Go files present in the directory. Workaround is to add dummy Go files.

Approach from: crawshaw/sqlite#88

Fixes karalabe/usb#13
