### PR TITLE
freebsd: remove outdated fix

### DIFF
--- a/hidapi/libusb/hid.c
+++ b/hidapi/libusb/hid.c
@@ -395,11 +395,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-#ifdef __FreeBSD__
-	const char *inptr;
-#else
 	char *inptr;
-#endif
 	char *outptr;
 #endif
 


### PR DESCRIPTION
FreeBSD's `iconv` used to accept a `**const char` as a second parameter, but it has been changed to the same signature as other unices in recent versions.