### PR TITLE
darwin_usb.c: Remove deprecated ATOMIC_VAR_INIT

### DIFF
--- a/libusb/libusb/os/darwin_usb.c
+++ b/libusb/libusb/os/darwin_usb.c
@@ -50,7 +50,7 @@
 #include <stdatomic.h>
 #define libusb_darwin_atomic_fetch_add(x, y) atomic_fetch_add(x, y)
 
-_Atomic int32_t initCount = ATOMIC_VAR_INIT(0);
+_Atomic int32_t initCount = 0;
 #else
 /* use darwin atomics if the target is older than 10.12 */
 #include <libkern/OSAtomic.h>


### PR DESCRIPTION
On MacOS 13.3.1 and Apple clang version 14.0.3 (as reported by gcc --version), I get this error:
> In file included from ./libs.go:50:
> ./libusb/libusb/os/darwin_usb.c:53:29: warning: macro 'ATOMIC_VAR_INIT' has been marked as deprecated [-Wdeprecated-pragma]

I think it's safe to just remove this in C11:

> ATOMIC_VAR_INIT, "This macro was a part of early draft design for C11 atomic types. It is not needed in C11, and is deprecated in C17 and removed in C23."
- https://en.cppreference.com/w/c/atomic/ATOMIC_VAR_INIT

see also
- https://en.cppreference.com/w/cpp/atomic/ATOMIC_VAR_INIT
- https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1138r0.pdf

