### PR TITLE
raw: use proper path with correct vendor id

### DIFF
--- a/raw_enabled.go
+++ b/raw_enabled.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License along
 // with the library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build (freebsd && cgo) || (linux && cgo) || (darwin && !ios && cgo) || (windows && cgo)
 // +build freebsd,cgo linux,cgo darwin,!ios,cgo windows,cgo
 
 package usb
@@ -34,9 +35,9 @@ import (
 
 // enumerateRaw returns a list of all the USB devices attached to the system which
 // match the vendor and product id:
-//  - If the vendor id is set to 0 then any vendor matches.
-//  - If the product id is set to 0 then any product matches.
-//  - If the vendor and product id are both 0, all USB devices are returned.
+//   - If the vendor id is set to 0 then any vendor matches.
+//   - If the product id is set to 0 then any product matches.
+//   - If the vendor and product id are both 0, all USB devices are returned.
 func enumerateRaw(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
 	// Enumerate the devices, and free all the matching refcounts (we'll reopen any
 	// explicitly requested).
@@ -147,7 +148,7 @@ func enumerateRawWithRef(vendorID uint16, productID uint16) ([]DeviceInfo, error
 
 						port := uint8(C.libusb_get_port_number(dev))
 						infos = append(infos, DeviceInfo{
-							Path:      fmt.Sprintf("%04x:%04x:%02d", vendorID, uint16(desc.idProduct), port),
+							Path:      fmt.Sprintf("%04x:%04x:%02d", uint16(desc.idVendor), uint16(desc.idProduct), port),
 							VendorID:  uint16(desc.idVendor),
 							ProductID: uint16(desc.idProduct),
 							Interface: ifacenum,


### PR DESCRIPTION
The method `enumerateRaw` takes two params, `vendorId` and `productId`. Any of them can be `0`, in which case, they're not used for matching. 

However, the code mistakenly used the `vendorId` (incoming parameter) to form part of the device address, instead of the actual `desc.idVendor`. This would work fine if the `vendorId` is used and matched, but if set to zero, results in an erroneous device path. 

With this PR, with a ledger nano x plugged in, I get
```
$ go run ./demo.go 
--------------------------------------------------------------------------------------------------------------------------------
HID #0
  OS Path:      0001:0004:00
  Vendor ID:    0x2c97
  Product ID:   0x4015
  Release:      513
  Serial:       
  Manufacturer: 
  Product:      
  Usage Page:   0
  Usage:        0
  Interface:    0
--------------------------------------------------------------------------------------------------------------------------------
HID #1
  OS Path:      0001:0004:01
  Vendor ID:    0x2c97
  Product ID:   0x4015
  Release:      513
  Serial:       
  Manufacturer: 
  Product:      
  Usage Page:   0
  Usage:        0
  Interface:    1
================================================================================================================================
RAW #0
  OS Path:    2c97:4015:01
  Vendor ID:  0x2c97
  Product ID: 0x4015
  Interface:  2
--------------------------------------------------------------------------------------------------------------------------------
```
Without the PR, it would spit out ` OS Path:    0000:4015:01`.
I think this matches the os

```
$ lsusb
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 001 Device 004: ID 2c97:4015 Ledger [unknown]
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub

$ lsusb -t -v 
/:  Bus 001.Port 001: Dev 001, Class=root_hub, Driver=vhci_hcd/8p, 480M
    ID 1d6b:0002 Linux Foundation 2.0 root hub
    |__ Port 001: Dev 004, If 0, Class=Human Interface Device, Driver=usbhid, 12M
        ID 2c97:4015 Ledger [unknown]
    |__ Port 001: Dev 004, If 1, Class=Human Interface Device, Driver=usbhid, 12M
        ID 2c97:4015 Ledger [unknown]
    |__ Port 001: Dev 004, If 2, Class=Vendor Specific Class, Driver=[none], 12M
        ID 2c97:4015 Ledger [unknown]
/:  Bus 002.Port 001: Dev 001, Class=root_hub, Driver=vhci_hcd/8p, 5000M
    ID 1d6b:0003 Linux Foundation 3.0 root hub
```
