### PR TITLE
remove filtering interrupt only raw devices

### DIFF
--- a/demo.go
+++ b/demo.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License along
 // with the library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build none
 // +build none
 
 package main
@@ -71,6 +72,7 @@ func main() {
 		fmt.Printf("  Vendor ID:  %#04x\n", raw.VendorID)
 		fmt.Printf("  Product ID: %#04x\n", raw.ProductID)
 		fmt.Printf("  Interface:  %d\n", raw.Interface)
+		fmt.Printf("  Serial:  %s\n", raw.Serial)
 		fmt.Println(strings.Repeat("-", 128))
 	}
 }


### PR DESCRIPTION
Some devices (such as MTP, audio, custom protocols) are not HID, and may not use interrupt transfers.

`enumerateRaw()` existing implementation filters by interrupt only, and as such many devices (including mobile phones such as Android which typically use bulk) will not be listed.
this change aims to fix that.
Also added serial number fetching for Raw devices too.